### PR TITLE
tokenBucket now functions 

### DIFF
--- a/lib/tokenBucket.js
+++ b/lib/tokenBucket.js
@@ -34,6 +34,7 @@ var TokenBucket = function(bucketSize, tokensPerInterval, interval, parentBucket
   
   this.parentBucket = parentBucket;
   this.content = 0;
+  this.capacity = 0.0;
   this.lastDrip = +new Date();
 };
 
@@ -43,6 +44,7 @@ TokenBucket.prototype = {
   interval: 1000,
   parentBucket: null,
   content: 0,
+  capacity: 0.0,
   lastDrip: 0,
   
   /**
@@ -75,6 +77,7 @@ TokenBucket.prototype = {
     
     // Drip new tokens into this bucket
     this.drip();
+    this.capacity = (1 - (this.content / this.bucketSize)) * 100;
     
     // If we don't have enough tokens in this bucket, come back later
     if (count > this.content) {
@@ -97,6 +100,7 @@ TokenBucket.prototype = {
    * @returns {Boolean} True if new tokens were added, otherwise false.
    */
   drip: function() {
+  
     if (!this.tokensPerInterval) {
       this.content = this.bucketSize;
       return;


### PR DESCRIPTION
When instantiating a tokenBucket, it always appeared to create a bucket of size `1` -- I've since fixed this issue for @LocalSense's needs, but please comment if there's something I've broken.
