### PR TITLE
Add support to fire callback immediately when rate limiting

### DIFF
--- a/lib/rateLimiter.js
+++ b/lib/rateLimiter.js
@@ -9,8 +9,10 @@ var TokenBucket = require('./tokenBucket');
  *  removed at any given moment and over the course of one interval.
  * @param {String|Number} interval The interval length in milliseconds, or as
  *  one of the following strings: 'second', 'minute', 'hour', day'.
+ * @param {Boolean} fireImmediately Optional. Whether or not the callback 
+ *  will fire immediately when rate limiting is in effect (default is false).
  */
-var RateLimiter = function(tokensPerInterval, interval) {
+var RateLimiter = function(tokensPerInterval, interval, fireImmediately) {
   this.tokenBucket = new TokenBucket(tokensPerInterval, tokensPerInterval,
     interval, null);
   
@@ -19,12 +21,14 @@ var RateLimiter = function(tokensPerInterval, interval) {
   
   this.curIntervalStart = +new Date();
   this.tokensThisInterval = 0;
+  this.fireImmediately = fireImmediately;
 };
 
 RateLimiter.prototype = {
   tokenBucket: null,
   curIntervalStart: 0,
   tokensThisInterval: 0,
+  fireImmediately: false,
   
   /**
    * Remove the requested number of tokens and fire the given callback. If the
@@ -58,13 +62,16 @@ RateLimiter.prototype = {
     // If we don't have enough tokens left in this interval, wait until the
     // next interval
     if (count > this.tokenBucket.tokensPerInterval - this.tokensThisInterval) {
-      var waitInterval = Math.ceil(
-        this.curIntervalStart + this.tokenBucket.interval - now);
-      
-      setTimeout(function() {
-        self.tokenBucket.removeTokens(count, afterTokensRemoved);
-      }, waitInterval);
-      
+      if (this.fireImmediately) {
+        callback(null, -1);
+      } else {
+        var waitInterval = Math.ceil(
+          this.curIntervalStart + this.tokenBucket.interval - now);
+
+        setTimeout(function() {
+          self.tokenBucket.removeTokens(count, afterTokensRemoved);
+        }, waitInterval);
+      }
       return false;
     }
     


### PR DESCRIPTION
This module was perfect for my needs, except I need to alert the client that rate limiting is in effect instead of just delaying the callback, so I added support for this in the RateLimiter. It simply fires the callback with remainingRequests set to -1, so that the fact that rate limiting is in effect can be easily detected from within the callback.

I also took the liberty of adding javascript code wrappers when updating the README.
