### PR TITLE
Fixed bug with stale token count

### DIFF
--- a/lib/rateLimiter.js
+++ b/lib/rateLimiter.js
@@ -91,6 +91,7 @@ RateLimiter.prototype = {
    * @returns {Number} The number of tokens remaining.
    */
   getTokensRemaining: function () {
+    this.tokenBucket.drip();
     return this.tokenBucket.content;
   }
 };


### PR DESCRIPTION
The getTokensRemaining function was returning a stale token count.

Needs to call tokenBucket.drip() to update the token count so that it is current at the time the count was requested.
