### PR TITLE
Implement `clearTimeouts` method to clear all queued requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,20 @@ var limiter = new RateLimiter(1, 250);
 limiter.getTokensRemaining();
 ```
 
+If you want to clear the queue of a token bucket (e.g. after the client disconnects), simply use the `clearTimeouts`-method.
+```javascript
+var RateLimiter = require('limiter').RateLimiter;
+var limiter = new RateLimiter(1, 250);
+
+limiter.removeTokens(1, function() {
+  callMyMessageSendingFunction(...);
+});
+
+// now we get an event that the client has disconnected and want to clear
+// the queue to make sure we don't parse throttled requests of a dead client
+limiter.clearTimeouts();
+```
+
 Using the token bucket directly to throttle at the byte level:
 
 ```javascript

--- a/lib/rateLimiter.js
+++ b/lib/rateLimiter.js
@@ -22,6 +22,8 @@ var RateLimiter = function(tokensPerInterval, interval, fireImmediately) {
   this.curIntervalStart = +new Date();
   this.tokensThisInterval = 0;
   this.fireImmediately = fireImmediately;
+
+  this.tokenTimeouts = [];
 };
 
 RateLimiter.prototype = {
@@ -68,9 +70,10 @@ RateLimiter.prototype = {
         var waitInterval = Math.ceil(
           this.curIntervalStart + this.tokenBucket.interval - now);
 
-        setTimeout(function() {
+        var tokenTimeout = setTimeout(function() {
           self.tokenBucket.removeTokens(count, afterTokensRemoved);
         }, waitInterval);
+        this.tokenTimeouts.push(tokenTimeout);
       }
       return false;
     }
@@ -124,6 +127,21 @@ RateLimiter.prototype = {
   getTokensRemaining: function () {
     this.tokenBucket.drip();
     return this.tokenBucket.content;
+  },
+
+  /**
+   * Clear all timeouts that were set in this limiter. (Drops all requests in the queue)
+   */
+  clearTimeouts: function() {
+    if (this.tokenBucket) {
+      // Clear the timeouts from the bucket first
+      this.tokenBucket.clearTimeouts();
+    }
+
+    // Clear the timeouts from the limiter
+    this.tokenTimeouts.forEach(function(tokenTimeout) {
+      clearTimeout(tokenTimeout);
+    });
   }
 };
 

--- a/lib/tokenBucket.js
+++ b/lib/tokenBucket.js
@@ -35,6 +35,7 @@ var TokenBucket = function(bucketSize, tokensPerInterval, interval, parentBucket
   this.parentBucket = parentBucket;
   this.content = 0;
   this.lastDrip = +new Date();
+  this.tokenTimeouts = [];
 };
 
 TokenBucket.prototype = {
@@ -105,7 +106,8 @@ TokenBucket.prototype = {
       // How long do we need to wait to make up the difference in tokens?
       var waitInterval = Math.ceil(
         (count - self.content) * (self.interval / self.tokensPerInterval));
-      setTimeout(function() { self.removeTokens(count, callback); }, waitInterval);
+      var tokenTimeout = setTimeout(function() { self.removeTokens(count, callback); }, waitInterval);
+      self.tokenTimeouts.push(tokenTimeout);
       return false;
     }
   },
@@ -159,6 +161,21 @@ TokenBucket.prototype = {
     
     var dripAmount = deltaMS * (this.tokensPerInterval / this.interval);
     this.content = Math.min(this.content + dripAmount, this.bucketSize);
+  },
+
+  /**
+   * Clear all timeouts that were set in this bucket. (Drops all requests in the queue)
+   */
+  clearTimeouts: function() {
+    if (this.parentBucket) {
+      // Clear the timeouts from the parent bucket first
+      this.parentBucket.clearTimeouts();
+    }
+
+    // Clear the timeouts from the bucket
+    this.tokenTimeouts.forEach(function(tokenTimeout) {
+      clearTimeout(tokenTimeout);
+    });
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "limiter",
+  "name": "limiter-plus",
   "description": "A generic rate limiter for node.js. Useful for API clients, web crawling, or other tasks that need to be throttled",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "author": "John Hurliman <jhurliman@cull.tv>",
   "dependencies": { },
   "devDependencies": {


### PR DESCRIPTION
I had the problem that throttled requests were still being processed after the client had disconnected. Now I just do `client.limiter.clearTimeouts()` in a disconnect event listener and everything is fine!