### PR TITLE
Defer calling callbacks until next event loop iteration

### DIFF
--- a/lib/rateLimiter.js
+++ b/lib/rateLimiter.js
@@ -15,10 +15,10 @@ var TokenBucket = require('./tokenBucket');
 var RateLimiter = function(tokensPerInterval, interval, fireImmediately) {
   this.tokenBucket = new TokenBucket(tokensPerInterval, tokensPerInterval,
     interval, null);
-  
+
   // Fill the token bucket to start
   this.tokenBucket.content = tokensPerInterval;
-  
+
   this.curIntervalStart = +new Date();
   this.tokensThisInterval = 0;
   this.fireImmediately = fireImmediately;
@@ -29,7 +29,7 @@ RateLimiter.prototype = {
   curIntervalStart: 0,
   tokensThisInterval: 0,
   fireImmediately: false,
-  
+
   /**
    * Remove the requested number of tokens and fire the given callback. If the
    * rate limiter contains enough tokens and we haven't spent too many tokens
@@ -43,27 +43,27 @@ RateLimiter.prototype = {
   removeTokens: function(count, callback) {
     // Make sure the request isn't for more than we can handle
     if (count > this.tokenBucket.bucketSize) {
-      callback('Requested tokens ' + count +
+      process.nextTick(callback.bind(null, 'Requested tokens ' + count +
         ' exceeds maximum tokens per interval ' + this.tokenBucket.bucketSize,
-        null);
+        null));
       return false;
     }
-    
+
     var self = this;
     var now = Date.now();
-    
+
     // Advance the current interval and reset the current interval token count
     // if needed
     if (now - this.curIntervalStart >= this.tokenBucket.interval) {
       this.curIntervalStart = now;
       this.tokensThisInterval = 0;
     }
-    
+
     // If we don't have enough tokens left in this interval, wait until the
     // next interval
     if (count > this.tokenBucket.tokensPerInterval - this.tokensThisInterval) {
       if (this.fireImmediately) {
-        callback(null, -1);
+        process.nextTick(callback.bind(null, null, -1));
       } else {
         var waitInterval = Math.ceil(
           this.curIntervalStart + this.tokenBucket.interval - now);
@@ -74,7 +74,7 @@ RateLimiter.prototype = {
       }
       return false;
     }
-    
+
     // Remove the requested number of tokens from the token bucket
     return this.tokenBucket.removeTokens(count, afterTokensRemoved);
 

--- a/lib/tokenBucket.js
+++ b/lib/tokenBucket.js
@@ -3,7 +3,7 @@
  * A hierarchical token bucket for rate limiting. See
  * http://en.wikipedia.org/wiki/Token_bucket for more information.
  * @author John Hurliman <jhurliman@cull.tv>
- * 
+ *
  * @param {Number} bucketSize Maximum number of tokens to hold in the bucket.
  *  Also known as the burst rate.
  * @param {Number} tokensPerInterval Number of tokens to drip into the bucket
@@ -16,7 +16,7 @@
 var TokenBucket = function(bucketSize, tokensPerInterval, interval, parentBucket) {
   this.bucketSize = bucketSize;
   this.tokensPerInterval = tokensPerInterval;
-  
+
   if (typeof interval === 'string') {
     switch (interval) {
       case 'sec': case 'second':
@@ -31,7 +31,7 @@ var TokenBucket = function(bucketSize, tokensPerInterval, interval, parentBucket
   } else {
     this.interval = interval;
   }
-  
+
   this.parentBucket = parentBucket;
   this.content = 0;
   this.lastDrip = +new Date();
@@ -44,7 +44,7 @@ TokenBucket.prototype = {
   parentBucket: null,
   content: 0,
   lastDrip: 0,
-  
+
   /**
    * Remove the requested number of tokens and fire the given callback. If the
    * bucket (and any parent buckets) contains enough tokens this will happen
@@ -57,36 +57,36 @@ TokenBucket.prototype = {
    */
   removeTokens: function(count, callback) {
     var self = this;
-    
+
     // Is this an infinite size bucket?
     if (!this.bucketSize) {
-      callback(null, count, Number.POSITIVE_INFINITY);
+      process.nextTick(callback.bind(null, null, count, Number.POSITIVE_INFINITY));
       return true;
     }
-    
+
     // Make sure the bucket can hold the requested number of tokens
     if (count > this.bucketSize) {
-      callback('Requested tokens ' + count + ' exceeds bucket size ' +
-        this.bucketSize, null);
+      process.nextTick(callback.bind(null, 'Requested tokens ' + count + ' exceeds bucket size ' +
+        this.bucketSize, null));
       return false;
     }
-    
+
     // Drip new tokens into this bucket
     this.drip();
-    
+
     // If we don't have enough tokens in this bucket, come back later
     if (count > this.content)
       return comeBackLater();
-    
+
     if (this.parentBucket) {
       // Remove the requested from the parent bucket first
       return this.parentBucket.removeTokens(count, function(err, remainingTokens) {
         if (err) return callback(err, null);
-        
+
         // Check that we still have enough tokens in this bucket
         if (count > self.content)
           return comeBackLater();
-        
+
         // Tokens were removed from the parent bucket, now remove them from
         // this bucket and fire the callback. Note that we look at the current
         // bucket and parent bucket's remaining tokens and return the smaller
@@ -97,10 +97,10 @@ TokenBucket.prototype = {
     } else {
       // Remove the requested tokens from this bucket and fire the callback
       this.content -= count;
-      callback(null, this.content);
+      process.nextTick(callback.bind(null, null, this.content));
       return true;
     }
-    
+
     function comeBackLater() {
       // How long do we need to wait to make up the difference in tokens?
       var waitInterval = Math.ceil(
@@ -122,11 +122,11 @@ TokenBucket.prototype = {
     // Is this an infinite size bucket?
     if (!this.bucketSize)
       return true;
-    
+
     // Make sure the bucket can hold the requested number of tokens
     if (count > this.bucketSize)
       return false;
-    
+
     // Drip new tokens into this bucket
     this.drip();
 
@@ -152,11 +152,11 @@ TokenBucket.prototype = {
       this.content = this.bucketSize;
       return;
     }
-    
+
     var now = +new Date();
     var deltaMS = Math.max(now - this.lastDrip, 0);
     this.lastDrip = now;
-    
+
     var dripAmount = deltaMS * (this.tokensPerInterval / this.interval);
     this.content = Math.min(this.content + dripAmount, this.bucketSize);
   }


### PR DESCRIPTION
It's kind of bad practice to call a callback right away within the same event loop iteration as it might cause synchronization issues, etc., so usually it's deferred by either using process.nextTick or setTimeout.