### PR TITLE
Start with a full tokenBucket

### DIFF
--- a/lib/tokenBucket.js
+++ b/lib/tokenBucket.js
@@ -33,7 +33,7 @@ var TokenBucket = function(bucketSize, tokensPerInterval, interval, parentBucket
   }
 
   this.parentBucket = parentBucket;
-  this.content = 0;
+  this.content = bucketSize;
   this.lastDrip = +new Date();
 };
 


### PR DESCRIPTION
I ran into issues where after creating a bucket on demand for new customers the customer would get rate limited right away. This was caused by the fact that a new bucket is empty. This PR changes  the code so a new bucket will start full.