### PR TITLE
Uses process.hrtime when possible, rather than the Date object, so that time is monotonic.

### DIFF
--- a/lib/clock.js
+++ b/lib/clock.js
@@ -1,0 +1,10 @@
+var getMilliseconds = function() {
+ if (typeof process === 'undefined') {
+   return new Date().getTime();
+ }
+
+ var [seconds, nanoseconds] = process.hrtime();
+ return seconds * 1e3 +  Math.floor(nanoseconds / 1e6);
+}
+
+module.exports = getMilliseconds;

--- a/lib/rateLimiter.js
+++ b/lib/rateLimiter.js
@@ -1,4 +1,5 @@
 var TokenBucket = require('./tokenBucket');
+var getMilliseconds = require('./clock');
 
 /**
  * A generic rate limiter. Underneath the hood, this uses a token bucket plus
@@ -19,7 +20,7 @@ var RateLimiter = function(tokensPerInterval, interval, fireImmediately) {
   // Fill the token bucket to start
   this.tokenBucket.content = tokensPerInterval;
 
-  this.curIntervalStart = +new Date();
+  this.curIntervalStart = getMilliseconds();
   this.tokensThisInterval = 0;
   this.fireImmediately = fireImmediately;
 };
@@ -50,7 +51,7 @@ RateLimiter.prototype = {
     }
 
     var self = this;
-    var now = Date.now();
+    var now = getMilliseconds();
 
     // Advance the current interval and reset the current interval token count
     // if needed
@@ -100,7 +101,7 @@ RateLimiter.prototype = {
     if (count > this.tokenBucket.bucketSize)
       return false;
 
-    var now = Date.now();
+    var now = getMilliseconds();
 
     // Advance the current interval and reset the current interval token count
     // if needed


### PR DESCRIPTION
This is a version of https://github.com/jhurliman/node-rate-limiter/pull/30 that falls back to using the `Date` object if `process` is not available.

Closes #22.