### PR TITLE
Eliminates module-scoped variables from tokenbucket-test.

### DIFF
--- a/lib/clock.js
+++ b/lib/clock.js
@@ -1,10 +1,13 @@
 var getMilliseconds = function() {
- if (typeof process === 'undefined') {
-   return new Date().getTime();
- }
+  if (typeof process !== 'undefined' && process.hrtime) {
+    var hrtime = process.hrtime();
+    var seconds = hrtime[0];
+    var nanoseconds = hrtime[1];
 
- var [seconds, nanoseconds] = process.hrtime();
- return seconds * 1e3 +  Math.floor(nanoseconds / 1e6);
+    return seconds * 1e3 +  Math.floor(nanoseconds / 1e6);
+  }
+
+  return new Date().getTime();
 }
 
 module.exports = getMilliseconds;

--- a/test/tokenbucket-test.js
+++ b/test/tokenbucket-test.js
@@ -4,62 +4,59 @@ var assert = require('assert');
 var TIMING_EPSILON = 10;
 
 var TokenBucket = require('../lib/tokenBucket');
-var gBucket;
-var gStart;
 
 vows.describe('TokenBucket').addBatch({
   'capacity 10, 1 per 100ms': {
     topic: new TokenBucket(10, 1, 100),
 
     'is initialized empty': function(bucket) {
-      gBucket = bucket;
       assert.equal(bucket.bucketSize, 10);
       assert.equal(bucket.tokensPerInterval, 1);
       assert.equal(bucket.content, 0);
     },
     'removing 10 tokens': {
       topic: function(bucket) {
-        gStart = +new Date();
+        this.gStart = +new Date();
         bucket.removeTokens(10, this.callback);
       },
       'takes 1 second': function(remainingTokens) {
-        var duration = +new Date() - gStart;
+        var duration = +new Date() - this.gStart;
         var diff = Math.abs(1000 - duration);
         assert.ok(diff < TIMING_EPSILON, diff+'');
         assert.equal(remainingTokens, 0);
       },
       'and removing another 10 tokens': {
-        topic: function() {
-          gStart = +new Date();
-          assert.equal(gBucket.content, 0);
-          gBucket.removeTokens(10, this.callback);
+        topic: function(_, bucket) {
+          this.gStart = +new Date();
+          assert.equal(bucket.content, 0);
+          bucket.removeTokens(10, this.callback);
         },
         'takes 1 second': function() {
-          var duration = +new Date() - gStart;
+          var duration = +new Date() - this.gStart;
           var diff = Math.abs(1000 - duration);
           assert.ok(diff < TIMING_EPSILON, diff+'');
         }
       },
       'and waiting 2 seconds': {
-        topic: function() {
+        topic: function(_, bucket) {
           var self = this;
           setTimeout(function() {
-            gStart = +new Date();
-            gBucket.removeTokens(10, self.callback);
+            self.gStart = +new Date();
+            bucket.removeTokens(10, self.callback);
           }, 2000);
         },
         'gives us only 10 tokens': function(remainingTokens) {
-          var duration = +new Date() - gStart;
+          var duration = +new Date() - this.gStart;
           assert.ok(duration < TIMING_EPSILON, duration+'');
           assert.equal(remainingTokens, 0);
         },
         'and removing 1 token': {
-          topic: function() {
-            gStart = +new Date();
-            gBucket.removeTokens(1, this.callback);
+          topic: function(_, _, bucket) {
+            this.gStart = +new Date();
+            bucket.removeTokens(1, this.callback);
           },
           'takes 100ms': function() {
-            var duration = +new Date() - gStart;
+            var duration = +new Date() - this.gStart;
             var diff = Math.abs(100 - duration);
             assert.ok(diff < TIMING_EPSILON, diff+'');
           }


### PR DESCRIPTION
The bucket is available in the nested scopes. The time variables are now attached to the context objects.

This change is intended to facilitate the addition of more tests, such as would be nice to have for https://github.com/jhurliman/node-rate-limiter/issues/18, to add tests for parent buckets, etc.