### PR TITLE
Higher token removals never fulfill

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 export type TokenBucketError = string
 export type Fail<T> = (error: T) => void
-export type Success<T> = (error: null, data: T, scheduled: number) => void
+export type Success<T> = (error: null, data: T, scheduledTokens: number) => void
 export type RemoveTokensCallback = Fail<TokenBucketError> | Success<number>
 
 type Interval = number | 'second' | 'sec' | 'minute' | 'min' | 'hour' | 'hr' | 'day'

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 export type TokenBucketError = string
 export type Fail<T> = (error: T) => void
-export type Success<T> = (error: null, data: T) => void
+export type Success<T> = (error: null, data: T, scheduled: number) => void
 export type RemoveTokensCallback = Fail<TokenBucketError> | Success<number>
 
 type Interval = number | 'second' | 'sec' | 'minute' | 'min' | 'hour' | 'hr' | 'day'

--- a/lib/tokenBucket.js
+++ b/lib/tokenBucket.js
@@ -87,7 +87,7 @@ TokenBucket.prototype = {
         if (err) return callback(err, null);
 
         // Check that we still have enough tokens in this bucket
-        if (count > (self.content - self.scheduledToken))
+        if (count > self.content)
           return comeBackLater();
 
         // Tokens were removed from the parent bucket, now remove them from

--- a/lib/tokenBucket.js
+++ b/lib/tokenBucket.js
@@ -35,6 +35,7 @@ var TokenBucket = function(bucketSize, tokensPerInterval, interval, parentBucket
   this.parentBucket = parentBucket;
   this.content = 0;
   this.lastDrip = +new Date();
+  this.scheduled = 0;
 };
 
 TokenBucket.prototype = {
@@ -44,6 +45,7 @@ TokenBucket.prototype = {
   parentBucket: null,
   content: 0,
   lastDrip: 0,
+  scheduled: 0,
 
   /**
    * Remove the requested number of tokens and fire the given callback. If the
@@ -75,8 +77,9 @@ TokenBucket.prototype = {
     this.drip();
 
     // If we don't have enough tokens in this bucket, come back later
-    if (count > this.content)
+    if (count > (this.content + this.scheduled))
       return comeBackLater();
+
 
     if (this.parentBucket) {
       // Remove the requested from the parent bucket first
@@ -103,9 +106,13 @@ TokenBucket.prototype = {
 
     function comeBackLater() {
       // How long do we need to wait to make up the difference in tokens?
+      this.scheduled += count;
       var waitInterval = Math.ceil(
-        (count - self.content) * (self.interval / self.tokensPerInterval));
-      setTimeout(function() { self.removeTokens(count, callback); }, waitInterval);
+        (this.scheduled - self.content) * (self.interval / self.tokensPerInterval));
+      setTimeout(function() {
+        this.scheduled -= count;
+        self.removeTokens(count, callback);
+      }, waitInterval);
       return false;
     }
   },
@@ -158,6 +165,7 @@ TokenBucket.prototype = {
     this.lastDrip = now;
 
     var dripAmount = deltaMS * (this.tokensPerInterval / this.interval);
+
     this.content = Math.min(this.content + dripAmount, this.bucketSize);
   }
 };

--- a/lib/tokenBucket.js
+++ b/lib/tokenBucket.js
@@ -35,7 +35,7 @@ var TokenBucket = function(bucketSize, tokensPerInterval, interval, parentBucket
   this.parentBucket = parentBucket;
   this.content = 0;
   this.lastDrip = +new Date();
-  this.scheduled = 0;
+  this.scheduledToken = 0;
 };
 
 TokenBucket.prototype = {
@@ -45,7 +45,7 @@ TokenBucket.prototype = {
   parentBucket: null,
   content: 0,
   lastDrip: 0,
-  scheduled: 0,
+  scheduledToken: 0,
 
   /**
    * Remove the requested number of tokens and fire the given callback. If the
@@ -62,14 +62,14 @@ TokenBucket.prototype = {
 
     // Is this an infinite size bucket?
     if (!this.bucketSize) {
-      process.nextTick(callback.bind(null, null, count, Number.POSITIVE_INFINITY));
+      process.nextTick(callback.bind(null, null, count, 0));
       return true;
     }
 
     // Make sure the bucket can hold the requested number of tokens
     if (count > this.bucketSize) {
       process.nextTick(callback.bind(null, 'Requested tokens ' + count + ' exceeds bucket size ' +
-        this.bucketSize, null));
+        this.bucketSize, null, 0));
       return false;
     }
 
@@ -77,7 +77,7 @@ TokenBucket.prototype = {
     this.drip();
 
     // If we don't have enough tokens in this bucket, come back later
-    if (count > (this.content - self.scheduled))
+    if (count > this.content)
       return comeBackLater();
 
 
@@ -87,7 +87,7 @@ TokenBucket.prototype = {
         if (err) return callback(err, null);
 
         // Check that we still have enough tokens in this bucket
-        if (count > (self.content - self.scheduled))
+        if (count > (self.content - self.scheduledToken))
           return comeBackLater();
 
         // Tokens were removed from the parent bucket, now remove them from
@@ -100,17 +100,17 @@ TokenBucket.prototype = {
     } else {
       // Remove the requested tokens from this bucket and fire the callback
       this.content -= count;
-      process.nextTick(callback.bind(null, null, this.content));
+      process.nextTick(callback.bind(null, null, this.content, self.scheduledToken));
       return true;
     }
 
     function comeBackLater() {
       // How long do we need to wait to make up the difference in tokens?
-        self.scheduled += count;
+      self.scheduledToken += count;  // keep our tokens in mind that are already reserved
       var waitInterval = Math.ceil(
-        (self.scheduled - self.content) * (self.interval / self.tokensPerInterval));
+        (self.scheduledToken - self.content) * (self.interval / self.tokensPerInterval));
       setTimeout(function() {
-          self.scheduled -= count;
+        self.scheduledToken -= count; // remove our used tokens from the scheduledToken counter
         self.removeTokens(count, callback);
       }, waitInterval);
       return false;

--- a/lib/tokenBucket.js
+++ b/lib/tokenBucket.js
@@ -35,7 +35,8 @@ var TokenBucket = function(bucketSize, tokensPerInterval, interval, parentBucket
   this.parentBucket = parentBucket;
   this.content = 0;
   this.lastDrip = +new Date();
-  this.scheduledToken = 0;
+  this.scheduledTokens = 0;
+  this.scheduledTime = new Date();
 };
 
 TokenBucket.prototype = {
@@ -45,15 +46,18 @@ TokenBucket.prototype = {
   parentBucket: null,
   content: 0,
   lastDrip: 0,
-  scheduledToken: 0,
+  scheduledTokens: 0,
+  scheduledTime: 0,
 
   /**
    * Remove the requested number of tokens and fire the given callback. If the
    * bucket (and any parent buckets) contains enough tokens this will happen
    * immediately. Otherwise, the removal and callback will happen when enough
    * tokens become available.
+   * The callback contains a scheduledTokens number that gives a hint for the
+   * already scheduled future tokens
    * @param {Number} count The number of tokens to remove.
-   * @param {Function} callback(err, remainingTokens)
+   * @param {Function} callback(err, remainingTokens, scheduledTokens)
    * @returns {Boolean} True if the callback was fired immediately, otherwise
    *  false.
    */
@@ -100,19 +104,31 @@ TokenBucket.prototype = {
     } else {
       // Remove the requested tokens from this bucket and fire the callback
       this.content -= count;
-      process.nextTick(callback.bind(null, null, this.content, self.scheduledToken));
+      process.nextTick(callback.bind(null, null, this.content, self.scheduledTokens));
       return true;
     }
 
     function comeBackLater() {
       // How long do we need to wait to make up the difference in tokens?
-      self.scheduledToken += count;  // keep our tokens in mind that are already reserved
       var waitInterval = Math.ceil(
-        (self.scheduledToken - self.content) * (self.interval / self.tokensPerInterval));
+        (count - self.content) * (self.interval / self.tokensPerInterval));
+
+      var now = Date.now();
+        // if there are no scheduledTokens, we reset the timer and put in the minimum waiting time
+      if(self.scheduledTokens === 0) {
+          self.scheduledTime = now;
+      }
+      // the waitInterval needs to be added to the already scheduled tokens.
+      self.scheduledTime += waitInterval;
+      // the realWaitInterval ends at the end of the max scheduledTime
+      var realWaitingInterval = self.scheduledTime - now;
+
+      // keep our tokens in mind that are already reserved  - the value is returned to the user
+      self.scheduledTokens += count;
       setTimeout(function() {
-        self.scheduledToken -= count; // remove our used tokens from the scheduledToken counter
+        self.scheduledTokens -= count; // remove the done tokens from the counter
         self.removeTokens(count, callback);
-      }, waitInterval);
+      }, realWaitingInterval);
       return false;
     }
   },

--- a/lib/tokenBucket.js
+++ b/lib/tokenBucket.js
@@ -77,7 +77,7 @@ TokenBucket.prototype = {
     this.drip();
 
     // If we don't have enough tokens in this bucket, come back later
-    if (count > (this.content + this.scheduled))
+    if (count > (this.content - this.scheduled))
       return comeBackLater();
 
 

--- a/lib/tokenBucket.js
+++ b/lib/tokenBucket.js
@@ -77,7 +77,7 @@ TokenBucket.prototype = {
     this.drip();
 
     // If we don't have enough tokens in this bucket, come back later
-    if (count > (this.content - this.scheduled))
+    if (count > (this.content - self.scheduled))
       return comeBackLater();
 
 
@@ -87,7 +87,7 @@ TokenBucket.prototype = {
         if (err) return callback(err, null);
 
         // Check that we still have enough tokens in this bucket
-        if (count > self.content)
+        if (count > (self.content - self.scheduled))
           return comeBackLater();
 
         // Tokens were removed from the parent bucket, now remove them from
@@ -106,11 +106,11 @@ TokenBucket.prototype = {
 
     function comeBackLater() {
       // How long do we need to wait to make up the difference in tokens?
-      this.scheduled += count;
+        self.scheduled += count;
       var waitInterval = Math.ceil(
-        (this.scheduled - self.content) * (self.interval / self.tokensPerInterval));
+        (self.scheduled - self.content) * (self.interval / self.tokensPerInterval));
       setTimeout(function() {
-        this.scheduled -= count;
+          self.scheduled -= count;
         self.removeTokens(count, callback);
       }, waitInterval);
       return false;

--- a/package.json
+++ b/package.json
@@ -6,20 +6,29 @@
   "scripts": {
     "test": "vows --spec"
   },
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "assert": "1.3.0",
     "vows": "0.8.1"
   },
-  "keywords": ["rate", "limiting", "throttling"],
+  "keywords": [
+    "rate",
+    "limiting",
+    "throttling"
+  ],
   "repository": "git://github.com/jhurliman/node-rate-limiter",
-  "bugs": { "url": "http://github.com/jhurliman/node-rate-limiter/issues" },
-  "directories": { "lib": "./lib/" },
+  "bugs": {
+    "url": "http://github.com/jhurliman/node-rate-limiter/issues"
+  },
+  "directories": {
+    "lib": "./lib/"
+  },
   "main": "./index.js",
   "types": "./index.d.ts",
-  "licenses": [{
-    "type": "MIT",
-    "url": "http://github.com/jhurliman/node-rate-limiter/raw/master/LICENSE.txt"
-  }]
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://github.com/jhurliman/node-rate-limiter/raw/master/LICENSE.txt"
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -6,29 +6,20 @@
   "scripts": {
     "test": "vows --spec"
   },
-  "dependencies": {},
+  "dependencies": {
+  },
   "devDependencies": {
     "assert": "1.3.0",
     "vows": "0.8.1"
   },
-  "keywords": [
-    "rate",
-    "limiting",
-    "throttling"
-  ],
+  "keywords": ["rate", "limiting", "throttling"],
   "repository": "git://github.com/jhurliman/node-rate-limiter",
-  "bugs": {
-    "url": "http://github.com/jhurliman/node-rate-limiter/issues"
-  },
-  "directories": {
-    "lib": "./lib/"
-  },
+  "bugs": { "url": "http://github.com/jhurliman/node-rate-limiter/issues" },
+  "directories": { "lib": "./lib/" },
   "main": "./index.js",
   "types": "./index.d.ts",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://github.com/jhurliman/node-rate-limiter/raw/master/LICENSE.txt"
-    }
-  ]
+  "licenses": [{
+    "type": "MIT",
+    "url": "http://github.com/jhurliman/node-rate-limiter/raw/master/LICENSE.txt"
+  }]
 }


### PR DESCRIPTION
Hi all.

I had a few problems with the TokenBucket and ended up with a fix in calculating the waiting time.
Most annoying was, that the TokenBucket did not let pass calls of different token-size-request.

The problem: if different operations work on the same TokenBucket with different number of tokens used, the operations with the higher number will be re-scheduled infinite.

orig:
```
function comeBackLater() {
  // How long do we need to wait to make up the difference in tokens?
  var waitInterval = Math.ceil(
    (count - self.content) * (self.interval / self.tokensPerInterval));
  setTimeout(function() { self.removeTokens(count, callback); }, waitInterval);
  return false;
}
```

What we can see here, is that overlapping intervals are not scheduled one after the other and faster timeouts will always eat the lower tokenBuckets from the internal counter. With full load, the self.removeTokens(count, callback) will never reach the token size required for the higher token-requests.

I added a third result value in the callback function (scheduledTokens) to give the user a feedback about how much tokens are already scheduled so that we can react if the number increases.

I ended up with this calculation:
```
function comeBackLater() {
      // How long do we need to wait to make up the difference in tokens?
      var waitInterval = Math.ceil(
        (count - self.content) * (self.interval / self.tokensPerInterval));

      var now = Date.now();
        // if there are no scheduledTokens, we reset the timer and put in the minimum waiting time
      if(self.scheduledTokens === 0) {
          self.scheduledTime = now;
      }
      // the waitInterval needs to be added to the already scheduled tokens.
      self.scheduledTime += waitInterval;
      // the realWaitInterval ends at the end of the max scheduledTime
      var realWaitingInterval = self.scheduledTime - now;

      // keep our tokens in mind that are already reserved  - the value is returned to the user
      self.scheduledTokens += count;
      setTimeout(function() {
        self.scheduledTokens -= count; // remove the done tokens from the counter
        self.removeTokens(count, callback);
      }, realWaitingInterval);
      return false;
    }
```

It may break the timing of tests (on my machine they are passing).