### PR TITLE
Option to create the bucket full

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,10 @@ export type RemoveTokensCallback = Fail<TokenBucketError> | Success<number>
 type Interval = number | 'second' | 'sec' | 'minute' | 'min' | 'hour' | 'hr' | 'day'
 
 export declare class TokenBucket {
-  constructor(bucketSize: number, tokensPerInterval: number, interval: Interval, parentBucket?: TokenBucket)
+  constructor(
+    bucketSize: number, tokensPerInterval: number, interval: Interval,
+    parentBucket?: TokenBucket, startFull?: boolean,
+  )
 
   removeTokens(count: number, callback: RemoveTokensCallback): void
   tryRemoveTokens(count: number): boolean

--- a/lib/tokenBucket.js
+++ b/lib/tokenBucket.js
@@ -30,7 +30,7 @@ var TokenBucket = function(bucketSize, tokensPerInterval, interval, parentBucket
       case 'day':
         this.interval = 1000 * 60 * 60 * 24; break;
       default:
-        throw new Error('Invaid interval ' + interval);
+        throw new Error('Invalid interval ' + interval);
     }
   } else {
     this.interval = interval;

--- a/lib/tokenBucket.js
+++ b/lib/tokenBucket.js
@@ -12,8 +12,10 @@
  *  one of the following strings: 'second', 'minute', 'hour', day'.
  * @param {TokenBucket} parentBucket Optional. A token bucket that will act as
  *  the parent of this bucket.
+ * @param {boolean} startFull Optional. Determines whether bucket should be
+ * created full or empty. Defaults to false.
  */
-var TokenBucket = function(bucketSize, tokensPerInterval, interval, parentBucket) {
+var TokenBucket = function(bucketSize, tokensPerInterval, interval, parentBucket, startFull=false) {
   this.bucketSize = bucketSize;
   this.tokensPerInterval = tokensPerInterval;
 
@@ -35,7 +37,7 @@ var TokenBucket = function(bucketSize, tokensPerInterval, interval, parentBucket
   }
 
   this.parentBucket = parentBucket;
-  this.content = 0;
+  this.content = startFull ? bucketSize : 0;
   this.lastDrip = +new Date();
 };
 

--- a/test/tokenbucket-test.js
+++ b/test/tokenbucket-test.js
@@ -64,4 +64,12 @@ vows.describe('TokenBucket').addBatch({
       }
     }
   },
+  'startsFull true': {
+    topic: new TokenBucket(10, 1, 100, undefined, true),
+    'is initialized full': function(bucket) {
+      assert.equal(bucket.bucketSize, 10);
+      assert.equal(bucket.tokensPerInterval, 1);
+      assert.equal(bucket.content, bucket.bucketSize);
+    }
+  }
 }).export(module);

--- a/test/tokenbucket-test.js
+++ b/test/tokenbucket-test.js
@@ -64,7 +64,7 @@ vows.describe('TokenBucket').addBatch({
       }
     }
   },
-  'startsFull true': {
+  'startFull true': {
     topic: new TokenBucket(10, 1, 100, undefined, true),
     'is initialized full': function(bucket) {
       assert.equal(bucket.bucketSize, 10);


### PR DESCRIPTION
Hello.

The reason I need is solely for testing sake, so I'll welcome any other suggestion for how to elegantly create a TokenBucket "ready to spill" without waiting for it or ugly monkeypatching. Still, I think it's a valuable functionality, and it maintains previous behavior.

Feel free to modify this PR of course.