### PR TITLE
Revert: Fix remainingRequests example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ var limiter = new RateLimiter(150, 'hour', true);  // fire CB immediately
 
 // Immediately send 429 header to client when rate limiting is in effect
 limiter.removeTokens(1, function(err, remainingRequests) {
-  if (remainingRequests < 1) {
+  if (remainingRequests < 0) {
     response.writeHead(429, {'Content-Type': 'text/plain;charset=UTF-8'});
     response.end('429 Too Many Requests - your IP is being rate limited');
   } else {


### PR DESCRIPTION
Thanks for awesome lib 🙏

This PR reverts fix 544a9007539d5af2323d38f05996c86edc8a87c4 that seems to have incorrectly updated the fire immediately example in the README.

To test, I used a very low rate limit of **2 / hour** and noted the remainingRequests values:

1. First call, remainingRequests = `1`
2. Second call, remainingRequests = `0.0017561111111110694`
3. Third call, remainingRequests = `-1` (as expected according to docs)

## What was expected to happen

Example should be failing on third call, with 2 valid executions.

## What actually happened

Example failed on second call, with 1 valid execution, i.e. 1 short of the target rate limit.