### PR TITLE
Enable ES Module usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "limiter",
   "description": "A generic rate limiter for the web and node.js. Useful for API clients, web crawling, or other tasks that need to be throttled",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "author": "John Hurliman <jhurliman@jhurliman.org>",
+  "type": "module",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "browser": "./dist/esm/index.js",


### PR DESCRIPTION
As noted in #80, es module imports are currently broken on the `2.1.0` release.

[According to the node docs](https://nodejs.org/docs/latest-v13.x/api/esm.html#esm_dual_commonjs_es_module_packages), the package.json `module` field is ignored. Instead, an [ES module can be signified using `"type": "module"`](https://nodejs.org/docs/latest-v13.x/api/esm.html#esm_approach_2_isolate_state).

In this PR:

- [x] Bump to 2.1.1
- [x] Add `"type": "module"`