### PR TITLE
fix import from ES Module

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "scripts": {
     "lint": "eslint --fix src",
-    "prepack": "yarn ttsc -p tsconfig.json && ttsc -p tsconfig.cjs.json",
+    "prepack": "yarn ttsc -p tsconfig.json && echo '{\n\t\"type\": \"module\"\n}' > dist/esm/package.json && ttsc -p tsconfig.cjs.json",
     "test": "jest src"
   },
   "dependencies": {


### PR DESCRIPTION
The problem was that Node was treating files in `dist/esm` as CommonJS. The solution would be to rename all files in `dist/esm` to `.mjs` or add a package.json with `type: module`. This PR chooses the second option.

Fixes #80