### PR TITLE
package.json: Set "type": "module"

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "A generic rate limiter for the web and node.js. Useful for API clients, web crawling, or other tasks that need to be throttled",
   "version": "2.1.0",
   "author": "John Hurliman <jhurliman@jhurliman.org>",
+  "type": "module",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "browser": "./dist/esm/index.js",


### PR DESCRIPTION
Fixes the following warning:

```
[MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///.../node_modules/limiter/dist/esm/index.js is not specified and it doesn't parse as CommonJS.
```